### PR TITLE
Add script for converting audio to 16kHz mono using ffmpeg

### DIFF
--- a/convert_to_16k_mono.py
+++ b/convert_to_16k_mono.py
@@ -1,0 +1,21 @@
+import os
+import subprocess
+from pathlib import Path
+
+input_dir = Path("2vec/data2wav_in")       # source folder
+output_dir = Path("2vec/data2wav_in_16k")  # output folder
+output_dir.mkdir(parents=True, exist_ok=True)
+
+for file_path in input_dir.iterdir():
+    if file_path.suffix.lower() in [".wav", ".flac"]:
+        out_path = output_dir / (file_path.stem + ".wav")
+        cmd = [
+            "ffmpeg", "-y",
+            "-i", str(file_path),
+            "-ac", "1",             # mono
+            "-ar", "16000",         # 16 kHz
+            str(out_path)
+        ]
+        subprocess.run(cmd, check=True)
+
+print("✅ Conversion complete.")


### PR DESCRIPTION
This utility script simplifies converting audio files to 16kHz mono format using ffmpeg. It's useful for ensuring compatibility with Wav2Vec and Data2Vec models that expect audio inputs in this format. Consider including this in the repository for preprocessing consistency and reproducibility.